### PR TITLE
Add jbundle.toml project configuration support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -919,6 +919,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "which",
@@ -1462,6 +1463,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1748,6 +1758,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -2250,6 +2301,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winsafe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1"
 sha2 = "0.10"
 tar = "0.4"
 tempfile = "3"
+toml = "0.8"
 thiserror = "2"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs"] }
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -101,6 +101,42 @@ jbundle info
 jbundle clean
 ```
 
+### Configuration file
+
+You can create an optional `jbundle.toml` in your project root to avoid repeating CLI flags:
+
+```toml
+# jbundle.toml
+java_version = 21
+target = "linux-x64"
+shrink = true
+jvm_args = ["-Xmx512m", "-XX:+UseZGC"]
+```
+
+All fields are optional. CLI flags always take precedence over the config file:
+
+```
+CLI flags > jbundle.toml > built-in defaults
+```
+
+### Supported JDK versions
+
+jbundle downloads JDK runtimes from [Adoptium](https://adoptium.net/). The `java_version` field (or `--java-version` flag) accepts the following versions:
+
+| Version | Type    | Status         |
+| ------- | ------- | -------------- |
+| `11`    | LTS     | Supported      |
+| `17`    | LTS     | Supported      |
+| `21`    | **LTS** | **Default**    |
+| `22`    | STS     | Supported      |
+| `23`    | STS     | Supported      |
+| `24`    | STS     | Supported      |
+| `25`    | LTS     | Supported      |
+
+LTS (Long-Term Support) versions are recommended for production. The default is `21` when not specified and not auto-detected from the JAR.
+
+> **Note:** Java 8 is not supported because jbundle relies on `jlink` and `jdeps`, which were introduced in Java 9.
+
 ### Supported platforms
 
 | Target          | Status    |

--- a/src/project_config.rs
+++ b/src/project_config.rs
@@ -1,0 +1,106 @@
+use std::path::Path;
+
+use anyhow::Result;
+use serde::Deserialize;
+
+const CONFIG_FILE: &str = "jbundle.toml";
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
+pub struct ProjectConfig {
+    pub java_version: Option<u8>,
+    pub target: Option<String>,
+    pub shrink: Option<bool>,
+    pub jvm_args: Option<Vec<String>>,
+}
+
+pub fn load_project_config(dir: &Path) -> Result<Option<ProjectConfig>> {
+    let config_path = dir.join(CONFIG_FILE);
+    if !config_path.exists() {
+        return Ok(None);
+    }
+
+    tracing::info!("loading config from {}", config_path.display());
+    let content = std::fs::read_to_string(&config_path)?;
+    let config: ProjectConfig =
+        toml::from_str(&content).map_err(|e| anyhow::anyhow!("invalid {}: {}", CONFIG_FILE, e))?;
+    Ok(Some(config))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn parse_full_config() {
+        let dir = tempdir().unwrap();
+        fs::write(
+            dir.path().join(CONFIG_FILE),
+            r#"
+java_version = 17
+target = "linux-x64"
+shrink = true
+jvm_args = ["-Xmx512m", "-XX:+UseZGC"]
+"#,
+        )
+        .unwrap();
+
+        let config = load_project_config(dir.path()).unwrap().unwrap();
+        assert_eq!(config.java_version, Some(17));
+        assert_eq!(config.target.as_deref(), Some("linux-x64"));
+        assert_eq!(config.shrink, Some(true));
+        assert_eq!(
+            config.jvm_args,
+            Some(vec!["-Xmx512m".to_string(), "-XX:+UseZGC".to_string()])
+        );
+    }
+
+    #[test]
+    fn parse_partial_config() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join(CONFIG_FILE), "java_version = 21\n").unwrap();
+
+        let config = load_project_config(dir.path()).unwrap().unwrap();
+        assert_eq!(config.java_version, Some(21));
+        assert_eq!(config.target, None);
+        assert_eq!(config.shrink, None);
+        assert_eq!(config.jvm_args, None);
+    }
+
+    #[test]
+    fn parse_empty_config() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join(CONFIG_FILE), "").unwrap();
+
+        let config = load_project_config(dir.path()).unwrap().unwrap();
+        assert_eq!(config.java_version, None);
+        assert_eq!(config.shrink, None);
+    }
+
+    #[test]
+    fn missing_file_returns_none() {
+        let dir = tempdir().unwrap();
+        let result = load_project_config(dir.path()).unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn invalid_toml_returns_error() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join(CONFIG_FILE), "not valid [[[toml").unwrap();
+
+        let result = load_project_config(dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn unknown_field_returns_error() {
+        let dir = tempdir().unwrap();
+        fs::write(dir.path().join(CONFIG_FILE), "unknown_field = true\n").unwrap();
+
+        let result = load_project_config(dir.path());
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
Users had to repeat CLI flags on every build. A per-project config file avoids that and makes builds reproducible across the team.