### PR TITLE
Add retry and file locking for JDK downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,6 +485,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -909,6 +919,7 @@ dependencies = [
  "clap",
  "dirs",
  "flate2",
+ "fs2",
  "indicatif",
  "regex",
  "reqwest",
@@ -2110,6 +2121,28 @@ dependencies = [
  "rustix",
  "winsafe",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 dirs = "6"
 flate2 = "1"
+fs2 = "0.4"
 indicatif = "0.18"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 serde = { version = "1", features = ["derive"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -25,6 +25,9 @@ pub enum PackError {
     #[error("jlink failed: {0}")]
     JlinkFailed(String),
 
+    #[error("cache lock timeout: another process is downloading JDK {version} for {target}")]
+    CacheLockTimeout { version: u8, target: String },
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 

--- a/src/jvm/download.rs
+++ b/src/jvm/download.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use std::time::Duration;
 
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use sha2::{Digest, Sha256};
@@ -7,6 +8,9 @@ use tokio::io::AsyncWriteExt;
 use crate::error::PackError;
 
 use super::adoptium::ReleaseAsset;
+
+const MAX_ATTEMPTS: u32 = 3;
+const INITIAL_BACKOFF_SECS: u64 = 1;
 
 pub async fn download_jdk(
     release: &ReleaseAsset,
@@ -30,13 +34,94 @@ pub async fn download_jdk(
 
     tracing::info!("downloading JDK from {url}");
 
+    let mut last_error = None;
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        match try_download(url, &dest, release.binary.package.size, mp).await {
+            Ok(()) => {
+                let actual_hash = file_sha256(&dest)?;
+                if actual_hash != *expected_sha {
+                    std::fs::remove_file(&dest).ok();
+                    return Err(PackError::ChecksumMismatch {
+                        expected: expected_sha.clone(),
+                        actual: actual_hash,
+                    });
+                }
+                return Ok(dest);
+            }
+            Err(DownloadAttemptError::Retryable(msg)) => {
+                last_error = Some(msg.clone());
+                std::fs::remove_file(&dest).ok();
+
+                if attempt < MAX_ATTEMPTS {
+                    let delay = INITIAL_BACKOFF_SECS * 2u64.pow(attempt - 1);
+                    tracing::warn!(
+                        "download failed, retrying in {delay}s... (attempt {}/{MAX_ATTEMPTS}): {msg}",
+                        attempt + 1
+                    );
+                    tokio::time::sleep(Duration::from_secs(delay)).await;
+                }
+            }
+            Err(DownloadAttemptError::Permanent(msg)) => {
+                std::fs::remove_file(&dest).ok();
+                return Err(PackError::JdkDownload(msg));
+            }
+            Err(DownloadAttemptError::RetryAfter(secs, msg)) => {
+                last_error = Some(msg.clone());
+                std::fs::remove_file(&dest).ok();
+
+                if attempt < MAX_ATTEMPTS {
+                    tracing::warn!(
+                        "rate limited, retrying in {secs}s... (attempt {}/{MAX_ATTEMPTS}): {msg}",
+                        attempt + 1
+                    );
+                    tokio::time::sleep(Duration::from_secs(secs)).await;
+                }
+            }
+        }
+    }
+
+    Err(PackError::JdkDownload(format!(
+        "download failed after {MAX_ATTEMPTS} attempts: {}",
+        last_error.unwrap_or_else(|| "unknown error".into())
+    )))
+}
+
+enum DownloadAttemptError {
+    Retryable(String),
+    Permanent(String),
+    RetryAfter(u64, String),
+}
+
+async fn try_download(
+    url: &str,
+    dest: &PathBuf,
+    fallback_size: u64,
+    mp: &MultiProgress,
+) -> Result<(), DownloadAttemptError> {
     let response = reqwest::get(url)
         .await
-        .map_err(|e| PackError::JdkDownload(format!("download failed: {e}")))?;
+        .map_err(|e| classify_reqwest_error(&e))?;
 
-    let total_size = response
-        .content_length()
-        .unwrap_or(release.binary.package.size);
+    let status = response.status();
+    if !status.is_success() {
+        let msg = format!("HTTP {status}");
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            let retry_after = response
+                .headers()
+                .get(reqwest::header::RETRY_AFTER)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(5);
+            return Err(DownloadAttemptError::RetryAfter(retry_after, msg));
+        }
+        if status.is_server_error() {
+            return Err(DownloadAttemptError::Retryable(msg));
+        }
+        return Err(DownloadAttemptError::Permanent(msg));
+    }
+
+    let total_size = response.content_length().unwrap_or(fallback_size);
 
     let pb = mp.add(ProgressBar::new(total_size));
     pb.set_style(
@@ -47,40 +132,51 @@ pub async fn download_jdk(
     );
     pb.set_message("Downloading JDK");
 
-    let mut file = tokio::fs::File::create(&dest).await?;
-    let mut hasher = Sha256::new();
+    let mut file = tokio::fs::File::create(&dest)
+        .await
+        .map_err(|e| DownloadAttemptError::Permanent(format!("create file: {e}")))?;
 
     let mut response = response;
     while let Some(chunk) = response
         .chunk()
         .await
-        .map_err(|e| PackError::JdkDownload(format!("download stream failed: {e}")))?
+        .map_err(|e| classify_reqwest_error(&e))?
     {
-        hasher.update(&chunk);
-        file.write_all(&chunk).await?;
+        file.write_all(&chunk)
+            .await
+            .map_err(|e| DownloadAttemptError::Permanent(format!("write file: {e}")))?;
         pb.inc(chunk.len() as u64);
     }
-    file.flush().await?;
+    file.flush()
+        .await
+        .map_err(|e| DownloadAttemptError::Permanent(format!("flush file: {e}")))?;
 
     pb.finish_and_clear();
-
-    let actual_hash = format!("{:x}", hasher.finalize());
-    if actual_hash != *expected_sha {
-        std::fs::remove_file(&dest)?;
-        return Err(PackError::ChecksumMismatch {
-            expected: expected_sha.clone(),
-            actual: actual_hash,
-        });
-    }
-
-    Ok(dest)
+    Ok(())
 }
 
-fn verify_checksum(path: &PathBuf, expected: &str) -> Result<bool, PackError> {
+fn classify_reqwest_error(e: &reqwest::Error) -> DownloadAttemptError {
+    if e.is_timeout() || e.is_connect() || e.is_request() {
+        DownloadAttemptError::Retryable(e.to_string())
+    } else if let Some(status) = e.status() {
+        if status.is_server_error() || status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            DownloadAttemptError::Retryable(e.to_string())
+        } else {
+            DownloadAttemptError::Permanent(e.to_string())
+        }
+    } else {
+        DownloadAttemptError::Retryable(e.to_string())
+    }
+}
+
+fn file_sha256(path: &PathBuf) -> Result<String, PackError> {
     let file = std::fs::File::open(path)?;
     let mut reader = std::io::BufReader::new(file);
     let mut hasher = Sha256::new();
     std::io::copy(&mut reader, &mut hasher)?;
-    let result = format!("{:x}", hasher.finalize());
-    Ok(result == expected)
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+fn verify_checksum(path: &PathBuf, expected: &str) -> Result<bool, PackError> {
+    Ok(file_sha256(path)? == expected)
 }

--- a/src/jvm/mod.rs
+++ b/src/jvm/mod.rs
@@ -3,11 +3,16 @@ pub mod cache;
 pub mod download;
 
 use std::path::PathBuf;
+use std::time::{Duration, Instant};
 
+use fs2::FileExt;
 use indicatif::MultiProgress;
 
 use crate::config::Target;
 use crate::error::PackError;
+
+const LOCK_TIMEOUT: Duration = Duration::from_secs(600); // 10 minutes
+const LOCK_POLL_INTERVAL: Duration = Duration::from_millis(500);
 
 pub async fn ensure_jdk(
     version: u8,
@@ -15,14 +20,60 @@ pub async fn ensure_jdk(
     mp: &MultiProgress,
 ) -> Result<PathBuf, PackError> {
     let cache_path = cache::cached_jdk_path(version, target)?;
+
+    // Fast path: already cached, no lock needed
     if cache_path.exists() {
         tracing::info!("using cached JDK {} at {}", version, cache_path.display());
         return Ok(cache_path);
     }
 
-    let release = adoptium::fetch_latest_release(version, target).await?;
-    let archive_path = download::download_jdk(&release, mp).await?;
-    let jdk_path = cache::extract_and_cache(version, target, &archive_path)?;
+    // Acquire file lock before download/extract
+    let lock_path = cache_path.with_extension("lock");
+    std::fs::create_dir_all(lock_path.parent().unwrap_or(&lock_path))?;
+    let lock_file = std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(&lock_path)?;
 
-    Ok(jdk_path)
+    let start = Instant::now();
+    let mut warned = false;
+    loop {
+        match lock_file.try_lock_exclusive() {
+            Ok(()) => break,
+            Err(_) => {
+                if start.elapsed() >= LOCK_TIMEOUT {
+                    return Err(PackError::CacheLockTimeout {
+                        version,
+                        target: format!("{}-{}", target.adoptium_os(), target.adoptium_arch()),
+                    });
+                }
+                if !warned {
+                    tracing::warn!(
+                        "waiting for another process to finish downloading JDK {version}..."
+                    );
+                    warned = true;
+                }
+                std::thread::sleep(LOCK_POLL_INTERVAL);
+            }
+        }
+    }
+
+    // Re-check after acquiring lock (another process may have populated the cache)
+    if cache_path.exists() {
+        tracing::info!("using cached JDK {} at {}", version, cache_path.display());
+        lock_file.unlock().ok();
+        return Ok(cache_path);
+    }
+
+    let result = async {
+        let release = adoptium::fetch_latest_release(version, target).await?;
+        let archive_path = download::download_jdk(&release, mp).await?;
+        cache::extract_and_cache(version, target, &archive_path)
+    }
+    .await;
+
+    lock_file.unlock().ok();
+
+    result
 }


### PR DESCRIPTION
Transient network failures (5xx, timeouts, connection resets) caused the entire build to fail with no recovery. Concurrent builds sharing the same cache could corrupt the JDK extraction.

Download now retries up to 3 times with exponential backoff (1s, 2s, 4s), respecting 429 Retry-After headers. Cache access is protected by an exclusive file lock with 10min timeout so parallel builds wait instead of corrupting each other.

fixed: #11
fixed: #13