### PR TITLE
Add SSL development libraries as pre-req

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -8,6 +8,8 @@ Currently, jbundle is installed from source using Cargo (Rust's package manager)
 
 * [Rust toolchain](https://rustup.rs/) (1.70+)
 * Git
+* SSL development libraries
+  * Debian/Ubuntu: `sudo apt update && sudo apt install libssl-dev`
 
 ### Steps
 


### PR DESCRIPTION
Before:

```
  cargo:rerun-if-env-changed=PKG_CONFIG_SYSROOT_DIR


  Could not find openssl via pkg-config:

  pkg-config exited with status code 1
  > PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags openssl

  The system library `openssl` required by crate `openssl-sys` was not found.
  The file `openssl.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.
  The PKG_CONFIG_PATH environment variable is not set.

  HINT: if you have installed the library, try setting PKG_CONFIG_PATH to the directory containing `openssl.pc`.


  cargo:warning=Could not find directory of OpenSSL installation, and this `-sys` crate cannot proceed without this knowledge. If OpenSSL is installed and this crate had trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the compilation process. See stderr section below for further information.

  --- stderr


  Could not find directory of OpenSSL installation, and this `-sys` crate cannot
  proceed without this knowledge. If OpenSSL is installed and this crate had
  trouble finding it,  you can set the `OPENSSL_DIR` environment variable for the
  compilation process.

  Make sure you also have the development packages of openssl installed.
  For example, `libssl-dev` on Ubuntu or `openssl-devel` on Fedora.

  If you're in a situation where you think the directory *should* be found
  automatically, please open a bug at https://github.com/rust-openssl/rust-openssl
  and include information about your system as well as this message.

  $HOST = x86_64-unknown-linux-gnu
  $TARGET = x86_64-unknown-linux-gnu
  openssl-sys = 0.9.111
```

After:

```
   Finished `release` profile [optimized + debuginfo] target(s) in 59.37s
  Installing /home/koppor/.cargo/bin/jbundle
   Installed package `jbundle v0.1.0 (/home/koppor/git-repositories/jbundle)` (executable `jbundle`)
```